### PR TITLE
Update to Go 1.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-alpine
+FROM golang:1.18.2-alpine
 
 # Turn off cgo for a more static binary.
 # Specify cache directory so that we can run as nobody to build the binary.
@@ -12,4 +12,4 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go install -v
+RUN go install -v -buildvcs=false

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/sensiblecodeio/associate-eip
 
-go 1.16
+go 1.18
 
 require github.com/aws/aws-sdk-go v1.39.4
+
+require github.com/jmespath/go-jmespath v0.4.0 // indirect


### PR DESCRIPTION
Also use `-buildvcs=false` for now which gives the previous behaviour,
without breaking the build.